### PR TITLE
feat(rag): Implement Agentic RAG pipeline with LlamaIndex

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -2,7 +2,8 @@ import { app, BrowserWindow, ipcMain } from 'electron';
 import path from 'path';
 import { spawn, ChildProcess } from 'child_process';
 import { SupervisorAgent } from '../agents/SupervisorAgent';
-import { CanvasService } from '../services/CanvasService'; // Assuming this service will be created
+import { CanvasService } from '../services/CanvasService';
+import { consentService } from '../services/ConsentService';
 import { RAGService } from '../services/RAGService';
 
 // Keep a global reference of the window object, if you don't, the window will

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { spawn, ChildProcess } from 'child_process';
 import { SupervisorAgent } from '../agents/SupervisorAgent';
 import { CanvasService } from '../services/CanvasService'; // Assuming this service will be created
+import { RAGService } from '../services/RAGService';
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -175,5 +176,21 @@ ipcMain.handle('run-canvas-ai', async (event, userPrompt: string, canvasState: a
     } catch (error: any) {
         console.error("Canvas AI service failed:", error);
         return { success: false, error: error.message };
+    }
+});
+
+ipcMain.handle('run-rag-query', async (event, filePath: string, query: string) => {
+    const geminiApiKey = process.env.GEMINI_API_KEY;
+    if (!geminiApiKey) {
+        return { error: "GEMINI_API_KEY is not set." };
+    }
+
+    try {
+        const ragService = RAGService.getInstance(geminiApiKey);
+        const result = await ragService.createAndQuery(filePath, query);
+        return { response: result };
+    } catch (error: any) {
+        console.error("RAG service failed:", error);
+        return { error: error.message || "An unknown error occurred in the RAG service." };
     }
 });

--- a/electron/services/RAGService.ts
+++ b/electron/services/RAGService.ts
@@ -1,0 +1,76 @@
+import {
+  VectorStoreIndex,
+  Gemini,
+  serviceContextFromDefaults,
+  SimpleDirectoryReader,
+} from "llamaindex";
+import path from "path";
+
+export class RAGService {
+  private static instance: RAGService;
+  private gemini: Gemini;
+
+  private constructor(apiKey: string) {
+    this.gemini = new Gemini({
+      apiKey,
+      model: "gemini-2.5-pro",
+    });
+  }
+
+  public static getInstance(apiKey: string): RAGService {
+    if (!RAGService.instance) {
+      RAGService.instance = new RAGService(apiKey);
+    }
+    return RAGService.instance;
+  }
+
+  public async createAndQuery(filePath: string, query: string): Promise<string> {
+    console.log(`[RAGService] Starting RAG query for file: ${filePath}`);
+
+    try {
+      // 1. Use SimpleDirectoryReader to load documents. This automatically handles
+      // different file types like .pdf, .md, .txt, etc.
+      const reader = new SimpleDirectoryReader();
+      // It expects a directory, so we pass the directory of the file
+      // and then filter to load only the specific file.
+      const documents = await reader.loadData({
+          directoryPath: path.dirname(filePath),
+          fs: {
+              ...require('fs/promises'),
+              readdir: async (dirPath) => {
+                  if (dirPath === path.dirname(filePath)) {
+                      return [path.basename(filePath)]; // Only "read" the target file
+                  }
+                  return [];
+              }
+          }
+      });
+      console.log(`[RAGService] Document loaded successfully using SimpleDirectoryReader.`);
+
+      // 2. Create a service context with the Gemini model
+      const serviceContext = serviceContextFromDefaults({
+        llm: this.gemini,
+      });
+      console.log(`[RAGService] Service context created.`);
+
+      // 3. Create an in-memory vector store index from the loaded documents
+      const index = await VectorStoreIndex.fromDocuments(documents, {
+        serviceContext,
+      });
+      console.log(`[RAGService] In-memory index created.`);
+
+      // 4. Create a query engine
+      const queryEngine = index.asQueryEngine();
+      console.log(`[RAGService] Query engine created.`);
+
+      // 5. Execute the query
+      const response = await queryEngine.query({ query });
+      console.log(`[RAGService] Query executed successfully.`);
+
+      return response.toString();
+    } catch (error) {
+      console.error("[RAGService] Error during RAG pipeline execution:", error);
+      throw new Error("Failed to process document and execute query.");
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "dotenv": "^17.2.1",
         "framer-motion": "^11.18.2",
         "langchain": "^0.3.0",
+        "llamaindex": "^0.11.27",
         "lucide-react": "^0.446.0",
         "mammoth": "^1.10.0",
         "monaco-editor": "^0.52.0",
@@ -211,6 +212,44 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.862.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.862.0.tgz",
+      "integrity": "sha512-Bei+RL0cDxxV+lW2UezLbCYYNeJm6Nzee0TpW0FfyTRBhH9C1XQh4+x+IClriXvgBnRquTMMYsmJfvx8iyLKrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -1725,6 +1764,117 @@
         "@langchain/core": ">=0.2.21 <0.4.0"
       }
     },
+    "node_modules/@llamaindex/core": {
+      "version": "0.6.20",
+      "resolved": "https://registry.npmjs.org/@llamaindex/core/-/core-0.6.20.tgz",
+      "integrity": "sha512-3Sq8eoNyHjF9yFdzHJKjHxVioQPKcp7YLp6PiwkWryev30H3EFIloAr5CvgppRHGmwlhbTwHsGp+SSfpWIdg/g==",
+      "dependencies": {
+        "@llamaindex/env": "0.1.30",
+        "@types/node": "^24.0.13",
+        "magic-bytes.js": "^1.10.0",
+        "zod": "^3.25.76",
+        "zod-to-json-schema": "^3.24.6"
+      }
+    },
+    "node_modules/@llamaindex/core/node_modules/@types/node": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
+    "node_modules/@llamaindex/core/node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "license": "MIT"
+    },
+    "node_modules/@llamaindex/env": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@llamaindex/env/-/env-0.1.30.tgz",
+      "integrity": "sha512-y6kutMcCevzbmexUgz+HXf7KiZemzAoFEYSjAILfR+cG6FmYSF8XvLbGOB34Kx8mlRi7EI8rZXpezJ5qCqOyZg==",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "js-tiktoken": "^1.0.12",
+        "pathe": "^1.1.2"
+      },
+      "peerDependencies": {
+        "@huggingface/transformers": "^3.5.0",
+        "gpt-tokenizer": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@huggingface/transformers": {
+          "optional": true
+        },
+        "gpt-tokenizer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@llamaindex/node-parser": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/@llamaindex/node-parser/-/node-parser-2.0.20.tgz",
+      "integrity": "sha512-9x/VqqrybWqFERui9H62AQqfJw0J0Hnzxcb501Ttt46nGnJXYIJ6DgcxA14EKlgEuiPRuYFMcXtO399ewnhteQ==",
+      "dependencies": {
+        "html-to-text": "^9.0.5"
+      },
+      "peerDependencies": {
+        "@llamaindex/core": "0.6.20",
+        "@llamaindex/env": "0.1.30",
+        "tree-sitter": "^0.22.0",
+        "web-tree-sitter": "^0.24.3"
+      }
+    },
+    "node_modules/@llamaindex/workflow": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/@llamaindex/workflow/-/workflow-1.1.21.tgz",
+      "integrity": "sha512-niNbmxUG+Czo3E7MJtu5GU4oTf2utzceA7xFUDFW0IMBcaap4FJItSr8UZbFj9uHa69SZrPmaZInXvOML6Onqw==",
+      "dependencies": {
+        "@llamaindex/workflow-core": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@llamaindex/core": "0.6.20",
+        "@llamaindex/env": "0.1.30",
+        "zod": "^3.25.67",
+        "zod-to-json-schema": "^3.24.6"
+      }
+    },
+    "node_modules/@llamaindex/workflow/node_modules/@llamaindex/workflow-core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/workflow-core/-/workflow-core-1.2.0.tgz",
+      "integrity": "sha512-yu1Q3NMbKDDDUwMIz3bR2mm9oe15y63lOqtVqqPxTR5gctMlXbYahHcsh++OLWh98ri3VOPyDgA0p0BdThNCqQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.7.0",
+        "hono": "^4.7.4",
+        "next": "^15.2.2",
+        "p-retry": "^6.2.1",
+        "rxjs": "^7.8.2",
+        "zod": "^3.24.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        },
+        "hono": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "p-retry": {
+          "optional": true
+        },
+        "rxjs": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
@@ -2856,6 +3006,19 @@
         "win32"
       ]
     },
+    "node_modules/@selderee/plugin-htmlparser2": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "selderee": "^0.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -3619,6 +3782,56 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
+      "integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -4017,6 +4230,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==",
+      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -5977,6 +6196,15 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -7764,6 +7992,41 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/html-to-text": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@selderee/plugin-htmlparser2": "^0.11.0",
+        "deepmerge": "^4.3.1",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^8.0.2",
+        "selderee": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/html-to-text/node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
@@ -8154,6 +8417,18 @@
       "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/is-network-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.1.0.tgz",
+      "integrity": "sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -8659,6 +8934,15 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/leac": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/lie": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
@@ -8686,6 +8970,123 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/llamaindex": {
+      "version": "0.11.27",
+      "resolved": "https://registry.npmjs.org/llamaindex/-/llamaindex-0.11.27.tgz",
+      "integrity": "sha512-UpVqxa+JSW6AvL0PgTZfuuhs9ujpXdnoUUQQBnV5CccEX1j/2GGQmKSS5xEsT/92ZjqIYfM5PyXViKGLE3XHYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@llamaindex/cloud": "4.1.2",
+        "@llamaindex/core": "0.6.20",
+        "@llamaindex/env": "0.1.30",
+        "@llamaindex/node-parser": "2.0.20",
+        "@llamaindex/workflow": "1.1.21",
+        "@types/lodash": "^4.17.7",
+        "@types/node": "^24.0.13",
+        "lodash": "^4.17.21",
+        "magic-bytes.js": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/llamaindex/node_modules/@llama-flow/core": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@llama-flow/core/-/core-0.4.4.tgz",
+      "integrity": "sha512-hwK1EQ+atUG/E7XcDV3KsTaA8op29pb8gbpVurpsqbLnGFkdTT4F/6V7Hy1cC2o/yOY+DKc/rxoIsH1uJS0cZg==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.7.0",
+        "hono": "^4.7.4",
+        "next": "^15.2.2",
+        "p-retry": "^6.2.1",
+        "rxjs": "^7.8.2",
+        "zod": "^3.24.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        },
+        "hono": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "p-retry": {
+          "optional": true
+        },
+        "rxjs": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/llamaindex/node_modules/@llamaindex/cloud": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@llamaindex/cloud/-/cloud-4.1.2.tgz",
+      "integrity": "sha512-UgCMsf7W4t5lqO8wMQZNA4mHYk8i1QbYr3RnLOCmHhfcJPGnoAupyVF2IBL0L0p++LThDyKHSxCdCM+OQZV3jQ==",
+      "license": "MIT",
+      "dependencies": {
+        "p-retry": "^6.2.1",
+        "zod": "^3.25.76"
+      },
+      "peerDependencies": {
+        "@llama-flow/core": "^0.4.1",
+        "@llamaindex/core": "0.6.20",
+        "@llamaindex/env": "0.1.30"
+      }
+    },
+    "node_modules/llamaindex/node_modules/@types/node": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
+    "node_modules/llamaindex/node_modules/@types/retry": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
+      "license": "MIT"
+    },
+    "node_modules/llamaindex/node_modules/p-retry": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.1.tgz",
+      "integrity": "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.2",
+        "is-network-error": "^1.0.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/llamaindex/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/llamaindex/node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "license": "MIT"
     },
     "node_modules/lodash": {
@@ -8800,6 +9201,12 @@
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.12.1.tgz",
+      "integrity": "sha512-ThQLOhN86ZkJ7qemtVRGYM+gRgR8GEXNli9H/PMvpnZsE44Xfh3wx9kGJaldg314v85m+bFW6WBMaVHJc/c3zA==",
+      "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.17",
@@ -9452,7 +9859,6 @@
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
       "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
       "license": "MIT",
-      "optional": true,
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -9865,6 +10271,19 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/parseley": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+      "license": "MIT",
+      "dependencies": {
+        "leac": "^0.6.0",
+        "peberminta": "^0.9.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -9939,6 +10358,12 @@
         "node": ">=16"
       }
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "license": "MIT"
+    },
     "node_modules/pdf-parse": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
@@ -9980,6 +10405,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/jet2jet"
+      }
+    },
+    "node_modules/peberminta": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/pend": {
@@ -10903,6 +11337,18 @@
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
       "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/selderee": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+      "license": "MIT",
+      "dependencies": {
+        "parseley": "^0.12.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -12134,6 +12580,28 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/tree-sitter": {
+      "version": "0.22.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
+      "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      }
+    },
+    "node_modules/tree-sitter/node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
@@ -12482,6 +12950,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/web-tree-sitter": {
+      "version": "0.24.7",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.24.7.tgz",
+      "integrity": "sha512-CdC/TqVFbXqR+C51v38hv6wOPatKEUGxa39scAeFSm98wIhZxAYonhRQPSMmfZ2w7JDI0zQDdzdmgtNk06/krQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1875,10 +1875,144 @@
         }
       }
     },
+    "node_modules/@llamaindex/core": {
+      "version": "0.6.20",
+      "resolved": "https://registry.npmjs.org/@llamaindex/core/-/core-0.6.20.tgz",
+      "integrity": "sha512-3Sq8eoNyHjF9yFdzHJKjHxVioQPKcp7YLp6PiwkWryev30H3EFIloAr5CvgppRHGmwlhbTwHsGp+SSfpWIdg/g==",
+      "dependencies": {
+        "@llamaindex/env": "0.1.30",
+        "@types/node": "^24.0.13",
+        "magic-bytes.js": "^1.10.0",
+        "zod": "^3.25.76",
+        "zod-to-json-schema": "^3.24.6"
+      }
+    },
+    "node_modules/@llamaindex/core/node_modules/@types/node": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
+    "node_modules/@llamaindex/core/node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "license": "MIT"
+    },
+    "node_modules/@llamaindex/env": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@llamaindex/env/-/env-0.1.30.tgz",
+      "integrity": "sha512-y6kutMcCevzbmexUgz+HXf7KiZemzAoFEYSjAILfR+cG6FmYSF8XvLbGOB34Kx8mlRi7EI8rZXpezJ5qCqOyZg==",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "js-tiktoken": "^1.0.12",
+        "pathe": "^1.1.2"
+      },
+      "peerDependencies": {
+        "@huggingface/transformers": "^3.5.0",
+        "gpt-tokenizer": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@huggingface/transformers": {
+          "optional": true
+        },
+        "gpt-tokenizer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@llamaindex/node-parser": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/@llamaindex/node-parser/-/node-parser-2.0.20.tgz",
+      "integrity": "sha512-9x/VqqrybWqFERui9H62AQqfJw0J0Hnzxcb501Ttt46nGnJXYIJ6DgcxA14EKlgEuiPRuYFMcXtO399ewnhteQ==",
+      "dependencies": {
+        "html-to-text": "^9.0.5"
+      },
+      "peerDependencies": {
+        "@llamaindex/core": "0.6.20",
+        "@llamaindex/env": "0.1.30",
+        "tree-sitter": "^0.22.0",
+        "web-tree-sitter": "^0.24.3"
+      }
+    },
+    "node_modules/@llamaindex/workflow": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/@llamaindex/workflow/-/workflow-1.1.21.tgz",
+      "integrity": "sha512-niNbmxUG+Czo3E7MJtu5GU4oTf2utzceA7xFUDFW0IMBcaap4FJItSr8UZbFj9uHa69SZrPmaZInXvOML6Onqw==",
+      "dependencies": {
+        "@llamaindex/workflow-core": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@llamaindex/core": "0.6.20",
+        "@llamaindex/env": "0.1.30",
+        "zod": "^3.25.67",
+        "zod-to-json-schema": "^3.24.6"
+      }
+    },
+    "node_modules/@llamaindex/workflow/node_modules/@llamaindex/workflow-core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@llamaindex/workflow-core/-/workflow-core-1.2.0.tgz",
+      "integrity": "sha512-yu1Q3NMbKDDDUwMIz3bR2mm9oe15y63lOqtVqqPxTR5gctMlXbYahHcsh++OLWh98ri3VOPyDgA0p0BdThNCqQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.7.0",
+        "hono": "^4.7.4",
+        "next": "^15.2.2",
+        "p-retry": "^6.2.1",
+        "rxjs": "^7.8.2",
+        "zod": "^3.24.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        },
+        "hono": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "p-retry": {
+          "optional": true
+        },
+        "rxjs": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
       "integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/malept"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+     "node_modules/@jest/snapshot-utils": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.0.5.tgz",
+      "integrity": "sha512-XcCQ5qWHLvi29UUrowgDFvV4t7ETxX91CbDczMnoqXPOIcZOxyNdSjm6kV5XMc8+HkxfRegU/MUmnTbJRzGrUQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "dotenv": "^17.2.1",
     "framer-motion": "^11.18.2",
     "langchain": "^0.3.0",
+    "llamaindex": "^0.11.27",
     "lucide-react": "^0.446.0",
     "mammoth": "^1.10.0",
     "monaco-editor": "^0.52.0",

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -8,7 +8,7 @@ const api: IElectronAPI = {
   getSettings: () => ipcRenderer.invoke('get-settings'),
   saveSettings: (settings: AppSettings) => ipcRenderer.invoke('save-settings', settings),
   openFile: () => ipcRenderer.invoke('open-file'),
-  processFile: (filePath: string, prompt: string) => ipcRenderer.invoke('process-file', filePath, prompt),
+  runRagQuery: (filePath: string, query: string) => ipcRenderer.invoke('run-rag-query', filePath, query),
   deepResearch: (prompt: string, modelName: string) => ipcRenderer.invoke('deep-research', prompt, modelName),
   
   // New: default chat with web search & citations

--- a/src/preload/types.d.ts
+++ b/src/preload/types.d.ts
@@ -4,7 +4,7 @@ export interface IElectronAPI {
   getSettings: () => Promise<AppSettings>;
   saveSettings: (settings: AppSettings) => Promise<void>;
   openFile: () => Promise<string | null>;
-  processFile: (filePath: string, prompt: string) => Promise<string>;
+  runRagQuery: (filePath: string, query: string) => Promise<{ response?: string; error?: string }>;
   deepResearch: (prompt: string, modelName: string) => Promise<{ answer: string; refinedQuery: string }>;
   
   // New: default web-search chat with citations

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -146,7 +146,9 @@ const App: React.FC = () => {
         aiResponseText = result.answer;
 
       } else if (attachedFile) {
-        aiResponseText = await window.api.processFile(attachedFile.path, userInput);
+        // Use the new RAG service when a file is attached
+        const result = await window.api.runRagQuery(attachedFile.path, userInput);
+        aiResponseText = result.response || `Error: ${result.error}`;
         setAttachedFile(null);
       } else {
         const result = await window.api.chatWithWeb(userInput, currentModelName);


### PR DESCRIPTION
This commit completes the objectives for Mission 3.

- Adds the `llamaindex` dependency to the project.
- Creates a new `RAGService` that uses LlamaIndex to build a retrieval-augmented generation pipeline. The service is configured to use the `gemini-2.5-pro` model.
- The `RAGService` now uses `SimpleDirectoryReader` to correctly parse various document formats, including PDF and Markdown, based on file extensions.
- Integrates the `RAGService` into the main Electron process with a new `run-rag-query` IPC handler.
- Updates the frontend application (`App.tsx` and preload scripts) to call this new handler when a user attaches a file to a message, enabling context-aware chat based on the document's content.